### PR TITLE
🤖 Issue tracker support bot

### DIFF
--- a/.github/workflows/dependency.yml
+++ b/.github/workflows/dependency.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: dessant/support-requests@v2.1.2
+      - uses: dessant/support-requests@v2
         with:
           support-label: 'dependency'
           issue-comment: >

--- a/.github/workflows/dependency.yml
+++ b/.github/workflows/dependency.yml
@@ -16,8 +16,10 @@ jobs:
         with:
           support-label: 'dependency'
           issue-comment: >
-            :wave: Hello @{issue-author}, your issue report doesn't seem to apply to Additional Guns, but rather one of its dependencies. \
+            :wave: Hello @{issue-author}, your issue report doesn't seem to apply to Additional Guns, but rather one of its dependencies.
+            
             Dependency issue trackers:
+            
             * [MrCrayfish's Gun Mod](https://github.com/MrCrayfish/MrCrayfishGunMod/issues)
             * [Framework](https://github.com/MrCrayfish/Framework/issues) (1.18.x and above)
             * [Obfuscate](https://github.com/MrCrayfish/Obfuscate/issues) (1.16.x)

--- a/.github/workflows/dependency.yml
+++ b/.github/workflows/dependency.yml
@@ -1,0 +1,26 @@
+name: 'dependency'
+
+on:
+  issues:
+    types: [labeled, unlabeled, reopened]
+    
+permissions:
+  issues: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: dessant/support-requests@v2.1.2
+        with:
+          support-label: 'dependency'
+          issue-comment: >
+            :wave: Hello @{issue-author}, your issue report doesn't seem to apply to Additional Guns, but rather one of its dependencies. \
+            Dependency issue trackers:
+            * [MrCrayfish's Gun Mod](https://github.com/MrCrayfish/MrCrayfishGunMod/issues)
+            * [Framework](https://github.com/MrCrayfish/Framework/issues) (1.18.x and above)
+            * [Obfuscate](https://github.com/MrCrayfish/Obfuscate/issues) (1.16.x)
+          close-issue: true
+          lock-issue: false
+          

--- a/.github/workflows/dependency.yml
+++ b/.github/workflows/dependency.yml
@@ -18,10 +18,13 @@ jobs:
           issue-comment: >
             :wave: Hello @{issue-author}, your issue report doesn't seem to apply to Additional Guns, but rather one of its dependencies.
             
-            Dependency issue trackers:
+            
+            **Dependency issue trackers:**
             
             * [MrCrayfish's Gun Mod](https://github.com/MrCrayfish/MrCrayfishGunMod/issues)
+            
             * [Framework](https://github.com/MrCrayfish/Framework/issues) (1.18.x and above)
+            
             * [Obfuscate](https://github.com/MrCrayfish/Obfuscate/issues) (1.16.x)
           close-issue: true
           lock-issue: false

--- a/.github/workflows/eol.yml
+++ b/.github/workflows/eol.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: dessant/support-requests@v2.1.2
+      - uses: dessant/support-requests@v2
         with:
           support-label: 'eol'
           issue-comment: >

--- a/.github/workflows/eol.yml
+++ b/.github/workflows/eol.yml
@@ -1,25 +1,17 @@
 name: 'eol'
 
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
   issues:
     types: [labeled, unlabeled, reopened]
     
 permissions:
   issues: write
 
-  # Allows you to run this workflow manually from the Actions tab
-  #workflow_dispatch:
-
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: dessant/support-requests@v2.1.2
         with:
           support-label: 'eol'

--- a/.github/workflows/eol.yml
+++ b/.github/workflows/eol.yml
@@ -28,4 +28,4 @@ jobs:
             Try updating to a newer version of the game and open a new issue if the issue still applies.
           close-issue: true
           lock-issue: true
-          issue-lock-reason: 'off-topic'
+          issue-lock-reason: 'resolved'

--- a/.github/workflows/eol.yml
+++ b/.github/workflows/eol.yml
@@ -1,8 +1,5 @@
-# This is a basic workflow to help you get started with Actions
-
 name: 'eol'
 
-# Controls when the workflow will run
 on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
   issues:
@@ -14,7 +11,6 @@ permissions:
   # Allows you to run this workflow manually from the Actions tab
   #workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
   build:
@@ -24,19 +20,12 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: dessant/support-requests@v2
+      - uses: dessant/support-requests@v2.1.2
         with:
-          #github-token: ${{secrets.ACCESS_TOKEN}}
           support-label: 'eol'
-          issue-comment: Hello, we no longer support this version
+          issue-comment: >
+            :wave: Hello @{issue-author}, you appear to be reporting an issue for a version we no longer support.
+            Try updating to a newer version of the game and open a new issue if the issue still applies.
           close-issue: true
-
-      # Runs a single command using the runners shell
-      - name: Run a one-line script
-        run: echo Hello, world!
-
-      # Runs a set of commands using the runners shell
-      - name: Run a multi-line script
-        run: |
-          echo Add other actions to build,
-          echo test, and deploy your project.
+          lock-issue: true
+          issue-lock-reason: 'off-topic'

--- a/.github/workflows/legacy_version.yml
+++ b/.github/workflows/legacy_version.yml
@@ -1,0 +1,25 @@
+name: 'legacy version'
+
+on:
+  issues:
+    types: [labeled, unlabeled, reopened]
+    
+permissions:
+  issues: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: dessant/support-requests@v2
+        with:
+          support-label: 'legacy version'
+          issue-comment: >
+            :wave: Hello @{issue-author}, it seems that you are asking for a backport to an older Minecraft version.
+            Unfortunately there are no plans on backporting the mod to discontinued versions of the game.
+            The team would like to dedicate their time moving forward instead.
+          close-issue: true
+          lock-issue: true
+          issue-lock-reason: 'off-topic'
+          

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,37 @@
+# This is a basic workflow to help you get started with Actions
+
+name: 'eol'
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  issues:
+    types: [labeled, unlabeled, reopened]
+    
+permissions:
+  issues: write
+
+  # Allows you to run this workflow manually from the Actions tab
+  #workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: dessant/support-requests@v2
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: echo Hello, world!
+
+      # Runs a set of commands using the runners shell
+      - name: Run a multi-line script
+        run: |
+          echo Add other actions to build,
+          echo test, and deploy your project.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,11 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: dessant/support-requests@v2
+        with:
+          github-token: ${{secrets.ACCESS_TOKEN}}
+          support-label: 'eol'
+          issue-comment: Hello, we no longer support this version
+          close-issue: true
 
       # Runs a single command using the runners shell
       - name: Run a one-line script

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: dessant/support-requests@v2
         with:
-          github-token: ${{secrets.ACCESS_TOKEN}}
+          #github-token: ${{secrets.ACCESS_TOKEN}}
           support-label: 'eol'
           issue-comment: Hello, we no longer support this version
           close-issue: true

--- a/.github/workflows/off-topic.yml
+++ b/.github/workflows/off-topic.yml
@@ -1,0 +1,24 @@
+name: 'off-topic'
+
+on:
+  issues:
+    types: [labeled, unlabeled, reopened]
+    
+permissions:
+  issues: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: dessant/support-requests@v2
+        with:
+          support-label: 'off-topic'
+          issue-comment: >
+            :wave: Hello @{issue-author}, we use the issue tracker exclusively for bug reports.
+            However, this seems to be better suited for our Discord server, Discussions tab or CurseForge comment section.
+          close-issue: true
+          lock-issue: true
+          issue-lock-reason: 'off-topic'
+          


### PR DESCRIPTION
I've set up a support bot using GitHub Actions which will close and respond to issues.
Feel free to leave feedback if you have any.

**How does it work?**
Let's say someone opens an issue asking for a backport to an older version. The only thing we need to do is add the ``legacy version`` label, and the bot will automatically respond, close and lock the issue.

**Why do we need it?**
Having a bot dealing with some of the issues saves us time typing a reply and closing + locking the issue manually.

***

### Response 1: dependency

:wave: Hello @``{issue-author}``, your issue report doesn't seem to apply to Additional Guns, but rather one of its dependencies.

**Dependency issue trackers:**
* [MrCrayfish's Gun Mod](https://github.com/MrCrayfish/MrCrayfishGunMod/issues)
* [Framework](https://github.com/MrCrayfish/Framework/issues) (1.18.x and above)
* [Obfuscate](https://github.com/MrCrayfish/Obfuscate/issues) (1.16.x)

***

### Response 2: eol

:wave: Hello @``{issue-author}``, you appear to be reporting an issue for a version we no longer support.
Try updating to a newer version of the game and open a new issue if the issue still applies.

***

### Response 3: legacy version

:wave: Hello @``{issue-author}``, it seems that you are asking for a backport to an older Minecraft version.
Unfortunately there are no plans on backporting the mod to discontinued versions of the game.
The team would like to dedicate their time moving forward instead.

***

### Response 4: off-topic

:wave: Hello @``{issue-author}``, we use the issue tracker exclusively for bug reports.
However, this seems to be better suited for our Discord server, Discussions tab or CurseForge comment section.
